### PR TITLE
Fix #24

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -35,7 +35,7 @@ fi
 
 ##################################
 
-scriptdir=$(dirname $(readlink -f $0))
+scriptdir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 owodir="$HOME/.config/owo"
 
 if [ -d $owodir ]; then


### PR DESCRIPTION
`DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"` is a replacement for the previous readlink command that works on all platforms.