### PR TITLE
Update maim to use --hidecursor in place of -u as not all versions of maim had the short switch

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -253,7 +253,7 @@ function screenshot() {
 		if is_mac; then
 			screencapture -o "${path}${filename}"
 		elif [[ $scr_cursor ]]; then 
-			maim -u "${path}${filename}"
+			maim --hidecursor "${path}${filename}"
 		else
 			maim "${path}${filename}"
 		fi
@@ -261,7 +261,7 @@ function screenshot() {
 		if is_mac; then
 			screencapture -o -i "${path}${filename}"
 		elif [[ $scr_cursor ]]; then
-			maim -s -u "${path}${filename}"
+			maim -s --hidecursor "${path}${filename}"
 		else
 			maim -s "${path}${filename}"
 		fi


### PR DESCRIPTION
Fixes `maim: invalid option -- 'u'` on certain distros (e.g Ubuntu 17.04)